### PR TITLE
Changing modal presentation behavior for ios13

### DIFF
--- a/src/ios/WebViewOverlayPlugin.m
+++ b/src/ios/WebViewOverlayPlugin.m
@@ -61,6 +61,10 @@
     webViewController.command = command;
     webViewController.title = titleString;
     
+    if (@available(iOS 13, *)) {
+        webViewController.modalInPresentation = true;
+    }
+    
     if ([webViewType isEqualToString :@"simple"]){
         
         [navController setNavigationBarHidden : NO animated : NO];


### PR DESCRIPTION
Since ios13, the screen is displayed as a modal and it is possible to swipe down and close the app. Presentation view here is changed, so that a swipe down is not possible.